### PR TITLE
feat: Additional colors for Widget

### DIFF
--- a/sources/widgets/widget.stTheme
+++ b/sources/widgets/widget.stTheme
@@ -57,6 +57,15 @@
       </dict>
       <dict>
         <key>scope</key>
+        <string>keyword.control.character-class</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string><%= scheme.base.red %></string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
         <string>constant</string>
         <key>settings</key>
         <dict>
@@ -66,7 +75,7 @@
       </dict>
       <dict>
         <key>scope</key>
-        <string>string</string>
+        <string>string, keyword.operator.quantifier</string>
         <key>settings</key>
         <dict>
           <key>foreground</key>

--- a/widgets/Widget - Boxy Monokai.stTheme
+++ b/widgets/Widget - Boxy Monokai.stTheme
@@ -57,6 +57,15 @@
       </dict>
       <dict>
         <key>scope</key>
+        <string>keyword.control.character-class</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#f92672</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
         <string>constant</string>
         <key>settings</key>
         <dict>
@@ -66,7 +75,7 @@
       </dict>
       <dict>
         <key>scope</key>
-        <string>string</string>
+        <string>string, keyword.operator.quantifier</string>
         <key>settings</key>
         <dict>
           <key>foreground</key>

--- a/widgets/Widget - Boxy Ocean.stTheme
+++ b/widgets/Widget - Boxy Ocean.stTheme
@@ -57,6 +57,15 @@
       </dict>
       <dict>
         <key>scope</key>
+        <string>keyword.control.character-class</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#ec5f67</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
         <string>constant</string>
         <key>settings</key>
         <dict>
@@ -66,7 +75,7 @@
       </dict>
       <dict>
         <key>scope</key>
-        <string>string</string>
+        <string>string, keyword.operator.quantifier</string>
         <key>settings</key>
         <dict>
           <key>foreground</key>

--- a/widgets/Widget - Boxy Tomorrow.stTheme
+++ b/widgets/Widget - Boxy Tomorrow.stTheme
@@ -57,6 +57,15 @@
       </dict>
       <dict>
         <key>scope</key>
+        <string>keyword.control.character-class</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#cc6666</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
         <string>constant</string>
         <key>settings</key>
         <dict>
@@ -66,7 +75,7 @@
       </dict>
       <dict>
         <key>scope</key>
-        <string>string</string>
+        <string>string, keyword.operator.quantifier</string>
         <key>settings</key>
         <dict>
           <key>foreground</key>

--- a/widgets/Widget - Boxy Yesterday.stTheme
+++ b/widgets/Widget - Boxy Yesterday.stTheme
@@ -57,6 +57,15 @@
       </dict>
       <dict>
         <key>scope</key>
+        <string>keyword.control.character-class</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#c82829</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
         <string>constant</string>
         <key>settings</key>
         <dict>
@@ -66,7 +75,7 @@
       </dict>
       <dict>
         <key>scope</key>
-        <string>string</string>
+        <string>string, keyword.operator.quantifier</string>
         <key>settings</key>
         <dict>
           <key>foreground</key>


### PR DESCRIPTION
Differentiate some regular expression scopes with more coloring, primarily character classes (`\w`) and quantifiers(`?`, `+`, `{1,4}`, etc.) that were rolled up into `keyword` and colored everything purple.