### PR TITLE
feat: Highlight string interpolation placeholders

### DIFF
--- a/schemes/Boxy Monokai.YAML-tmTheme
+++ b/schemes/Boxy Monokai.YAML-tmTheme
@@ -31,7 +31,7 @@ settings:
     fontStyle: 'italic'
 
 - name: Variable
-  scope: variable
+  scope: variable, string constant.other.placeholder
   settings:
     foreground: '#f8f8f2'
 

--- a/schemes/Boxy Monokai.tmTheme
+++ b/schemes/Boxy Monokai.tmTheme
@@ -56,7 +56,7 @@
 			<key>name</key>
 			<string>Variable</string>
 			<key>scope</key>
-			<string>variable</string>
+			<string>variable, string constant.other.placeholder</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>

--- a/schemes/Boxy Ocean.YAML-tmTheme
+++ b/schemes/Boxy Ocean.YAML-tmTheme
@@ -31,7 +31,7 @@ settings:
     fontStyle: 'italic'
 
 - name: Variable
-  scope: variable
+  scope: variable, string constant.other.placeholder
   settings:
     foreground: '#cdd3de'
 

--- a/schemes/Boxy Ocean.tmTheme
+++ b/schemes/Boxy Ocean.tmTheme
@@ -56,7 +56,7 @@
 			<key>name</key>
 			<string>Variable</string>
 			<key>scope</key>
-			<string>variable</string>
+			<string>variable, string constant.other.placeholder</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>

--- a/schemes/Boxy Tomorrow.YAML-tmTheme
+++ b/schemes/Boxy Tomorrow.YAML-tmTheme
@@ -31,7 +31,7 @@ settings:
     fontStyle: 'italic'
 
 - name: Variable
-  scope: variable
+  scope: variable, string constant.other.placeholder
   settings:
     foreground: '#c5c8c6'
 

--- a/schemes/Boxy Tomorrow.tmTheme
+++ b/schemes/Boxy Tomorrow.tmTheme
@@ -56,7 +56,7 @@
 			<key>name</key>
 			<string>Variable</string>
 			<key>scope</key>
-			<string>variable</string>
+			<string>variable, string constant.other.placeholder</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>

--- a/schemes/Boxy Yesterday.YAML-tmTheme
+++ b/schemes/Boxy Yesterday.YAML-tmTheme
@@ -31,7 +31,7 @@ settings:
     fontStyle: 'italic'
 
 - name: Variable
-  scope: variable
+  scope: variable, string constant.other.placeholder
   settings:
     foreground: '#4d4d4c'
 

--- a/schemes/Boxy Yesterday.tmTheme
+++ b/schemes/Boxy Yesterday.tmTheme
@@ -56,7 +56,7 @@
 			<key>name</key>
 			<string>Variable</string>
 			<key>scope</key>
-			<string>variable</string>
+			<string>variable, string constant.other.placeholder</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>

--- a/sources/schemes/scheme.YAML-tmTheme
+++ b/sources/schemes/scheme.YAML-tmTheme
@@ -31,7 +31,7 @@ settings:
     fontStyle: 'italic'
 
 - name: Variable
-  scope: variable
+  scope: variable, string constant.other.placeholder
   settings:
     foreground: '<%= scheme.foreground %>'
 


### PR DESCRIPTION
In languages with recognized placeholders for interpolation, this will highlight them with the foreground color.
e.g. Python:
```py
foo = 'bar %s, %d' % ('baz', 42)
```

Some more complicated Python placeholders are not currently recognized by Sublime, but I'm working on that. 😉 